### PR TITLE
Skip cleanup if 'src' missing

### DIFF
--- a/lib/html2doc/mime.rb
+++ b/lib/html2doc/mime.rb
@@ -107,12 +107,13 @@ module Html2Doc
   # only processes locally stored images
   def self.image_cleanup(docxml, dir, localdir)
     docxml.traverse do |i|
+      src = i["src"]
       next unless i.element? && %w(img v:imagedata).include?(i.name)
-      next if /^http/.match? i["src"]
-      next if %r{^data:(image|application)/[^;]+;base64}.match? i["src"]
+      next if src.nil? || src.empty? || /^http/.match?(src)
+      next if %r{^data:(image|application)/[^;]+;base64}.match? src
 
-      local_filename = localname(i["src"], localdir)
-      new_filename = "#{mkuuid}#{File.extname(i['src'])}"
+      local_filename = localname(src, localdir)
+      new_filename = "#{mkuuid}#{File.extname(src)}"
       FileUtils.cp local_filename, File.join(dir, new_filename)
       i["width"], i["height"] = image_resize(i, local_filename, 680, 400)
       i["src"] = File.join(File.basename(dir), new_filename)


### PR DESCRIPTION
### Intro

The issue was discovered on docker (where `inkscape` missing) and this lead for such issue

<details>
    <summary>stacktrace</summary>
  
	```
	Is a directory - read
	/usr/local/lib/ruby/2.7.0/fileutils.rb:1416:in `copy_stream'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:1416:in `block (2 levels) in copy_file'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:1415:in `open'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:1415:in `block in copy_file'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:1414:in `open'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:1414:in `copy_file'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:511:in `copy_file'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:430:in `block in cp'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:1589:in `block in fu_each_src_dest'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:1605:in `fu_each_src_dest0'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:1587:in `fu_each_src_dest'
	/usr/local/lib/ruby/2.7.0/fileutils.rb:429:in `cp'
	/usr/local/bundle/gems/html2doc-1.3.0.1/lib/html2doc/mime.rb:116:in `block in image_cleanup'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:979:in `traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `block in traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `block in traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `block in traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `block in traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `block in traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `block in traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `block in traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `block in traverse'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
	/usr/local/bundle/gems/nokogiri-1.12.5-x86_64-linux/lib/nokogiri/xml/node.rb:978:in `traverse'
	/usr/local/bundle/gems/html2doc-1.3.0.1/lib/html2doc/mime.rb:109:in `image_cleanup'
	/usr/local/bundle/gems/html2doc-1.3.0.1/lib/html2doc/base.rb:56:in `cleanup'
	/usr/local/bundle/gems/html2doc-1.3.0.1/lib/html2doc/base.rb:44:in `process_html'
	/usr/local/bundle/gems/html2doc-1.3.0.1/lib/html2doc/base.rb:10:in `process'
	/usr/local/bundle/gems/metanorma-ogc-2.0.2/lib/isodoc/ogc/word_convert.rb:237:in `toWord'
	/usr/local/bundle/gems/isodoc-2.0.2/lib/isodoc/word_function/postprocess.rb:36:in `postprocess'
	/usr/local/bundle/gems/isodoc-2.0.2/lib/isodoc/convert.rb:186:in `convert'
	/usr/local/bundle/gems/isodoc-2.0.2/lib/isodoc/word_convert.rb:20:in `convert'
	/usr/local/bundle/gems/metanorma-ogc-2.0.2/lib/metanorma/ogc/processor.rb:47:in `output'
	/usr/local/bundle/gems/metanorma-1.4.4/lib/metanorma/compile.rb:199:in `process_output_threaded'
	/usr/local/bundle/gems/metanorma-1.4.4/lib/metanorma/compile.rb:191:in `block in process_exts1'
	/usr/local/bundle/gems/metanorma-1.4.4/lib/metanorma/worker_pool.rb:11:in `block (4 levels) in initialize'
	/usr/local/bundle/gems/metanorma-1.4.4/lib/metanorma/worker_pool.rb:9:in `loop'
	/usr/local/bundle/gems/metanorma-1.4.4/lib/metanorma/worker_pool.rb:9:in `block (3 levels) in initialize'
	/usr/local/bundle/gems/metanorma-1.4.4/lib/metanorma/worker_pool.rb:8:in `catch'
	/usr/local/bundle/gems/metanorma-1.4.4/lib/metanorma/worker_pool.rb:8:in `block (2 levels) in initialize'
	```

</details>

### Proposed fix

Skip cleanup if `src` attribute is missing