### PR TITLE
chore: remove lutaml-model dependency

### DIFF
--- a/html2doc.gemspec
+++ b/html2doc.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "base64"
   spec.add_dependency "htmlentities", "~> 4.3.4"
-  spec.add_dependency "lutaml-model", "~> 0.7.0"
+
   spec.add_dependency "marcel"
   spec.add_dependency "metanorma-utils", ">= 1.9.0"
   spec.add_dependency "nokogiri", "~> 1.18.3"


### PR DESCRIPTION
This is to test the new lutaml-model 0.8.0 version. Do not merge yet.