### PR TITLE
Cimas sync 2026-06-29: Ruby 3.3 floor + template refresh

### DIFF
--- a/html2doc.gemspec
+++ b/html2doc.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features|bin|.github)/}) \
     || f.match(%r{Rakefile|bin/rspec})
   end
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
 
   spec.add_dependency "base64"
   spec.add_dependency "htmlentities", "~> 4.3.4"


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/274

Part of the cimas-sync 2026-06-29 wave bringing the repo into template-current state.

## Scope

Depending on the repo, this PR may carry some or all of:

- `<gem>.gemspec`: bumps `required_ruby_version` to `>= 3.3.0` (per the centralised `patches: ruby_version` block in [`metanorma/ci:cimas-config/cimas.yml`](https://github.com/metanorma/ci/blob/main/cimas-config/cimas.yml)).
- `.github/workflows/rake.yml`: adds workflow-level `permissions: contents: write` (template-forward; closes the [`metanorma/ci#272`](https://github.com/metanorma/ci/issues/272)/[`#276`](https://github.com/metanorma/ci/issues/276) Consequence-1 cap-failure mode if any cap drops to `read`).
- `.github/workflows/release.yml`: doc-string update for the `next_version` input description.
- `.rubocop.yml`: updates the `riboseinc/oss-guides` URL from `master` to `main`; bumps `TargetRubyVersion` from `2.5` to `3.4` (consistent with the gemspec floor where applicable).
- `Gemfile` / `Makefile` (model repos only): template-forward updates — `lutaml-xsd` removal from Gemfile, `-t png` flag added to `lutaml lml generate` in Makefile.
- `templates/base/*` (metanorma-cli only): updates the project-template files generated by `metanorma new` to current org standards (workflow `permissions: contents: read` blocks; `.gitlab-ci.yml` switched to a single `include: - remote: 'docker.shared.yml'`).

Wave context: one of ~21 sibling PRs across the cimas-managed repos. The wave's full scope and the deprecation triage (which dropped `metanorma-csa`, `metanorma-m3aawg`, `metanorma-un`, `iso690render`, and the `pubid-*` standalone family for being superseded) is recorded in the SSOT at [`metanorma/cimas:plans/cimas-revival-and-release-workflow-realignment.md`](https://github.com/metanorma/cimas/blob/main/plans/cimas-revival-and-release-workflow-realignment.md).

## Verification

The standard `rake` matrix against `[3.3, 3.4, 4.0-experimental]` (per `ruby-matrix.json`) should pass green.

🤖
