### PR TITLE
Relax plurimath constraint to >= 0.10.1

### DIFF
--- a/html2doc.gemspec
+++ b/html2doc.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "metanorma-utils", ">= 1.9.0"
   spec.add_dependency "nokogiri", "~> 1.19"
   spec.add_dependency "plane1converter", "~> 0.0.1"
-  spec.add_dependency "plurimath", "~> 0.10.1"
+  spec.add_dependency "plurimath", ">= 0.10.1"
   spec.add_dependency "thread_safe"
   spec.add_dependency "uuidtools"
   spec.add_dependency "vectory", "~> 0.10"

--- a/lib/html2doc/version.rb
+++ b/lib/html2doc/version.rb
@@ -1,3 +1,3 @@
 class Html2Doc
-  VERSION = "1.11.1".freeze
+  VERSION = "1.12.0".freeze
 end


### PR DESCRIPTION
Allow plurimath 0.11.x which uses mml >= 2.3. Bump to 1.12.0.